### PR TITLE
ING-249 Adapt plugin to Noop tracer, improve logs readability, fix formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ typings/
 
 # package-lock.json
 package-lock.json
+
+# IDEA files
+.idea
+*.iml

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "fastify-plugin": "^1.6.1",
-    "jaeger-client": "^3.17.2"
+    "jaeger-client": "^3.17.2",
+    "uri-js": "^4.4.1"
   }
 }


### PR DESCRIPTION
This PR introduces following changes to Penneo's fork of fastify-jaeger plugin:

1. Make it work properly with NoOp tracer (one used when JAEGER_DISABLED flag is set to true). That required performing some operations conditonally
2. Do not include query params in span name. I believe that improves readability and this is also how Jaeger does it itself:

![jaeger](https://user-images.githubusercontent.com/18010262/144023968-e969d3e0-4a55-46ab-859e-63a375fc255c.PNG)

3. Some formatting fixes